### PR TITLE
Fix ngModel binding for p-multiselect

### DIFF
--- a/AvidTravel.UI/src/app/features/home/home.component.ts
+++ b/AvidTravel.UI/src/app/features/home/home.component.ts
@@ -1,9 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { DestinationService } from '../../core/services/destination.services';
 import { Destination } from '../../core/models/destination.model';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MultiSelectModule } from 'primeng/multiselect';
 
 @Component({
+  standalone: true,
   selector: 'app-home',
+  imports: [CommonModule, FormsModule, MultiSelectModule],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css'],
 })


### PR DESCRIPTION
Make `HomeComponent` standalone and import `FormsModule` and `MultiSelectModule` to resolve the `NG8002` error with `p-multiselect`.

---
<a href="https://cursor.com/background-agent?bcId=bc-59cb07f1-1157-4f38-92fd-6b7a12e03cbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59cb07f1-1157-4f38-92fd-6b7a12e03cbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

